### PR TITLE
[Bug] SC-171547 Allow IFrames Height and Width to be defined in settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,22 @@
       "validationPattern": "^https:\\/\\/[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,}(\\/\\S*)?$",
       "isRequired": true,
       "isBackendOnly": false
+    },
+    "iframe_height_pixels": {
+      "title": "Column Height",
+      "description": "The height of the column in which the iframe will be displayed",
+      "validationPattern": "^\\d+$",
+      "type": "string",
+      "isRequired": true,
+      "isBackendOnly": false
+    },
+    "iframe_width_pixels": {
+      "title": "Column Width",
+      "description": "The width of the column in which the iframe will be displayed",
+      "validationPattern": "^\\d+$",
+      "type": "string",
+      "isRequired": true,
+      "isBackendOnly": false
     }
   }
 }


### PR DESCRIPTION
# Evidence
![image](https://github.com/user-attachments/assets/833be73d-0ac4-4eaa-8f64-01a30438eeb1)
![image](https://github.com/user-attachments/assets/803dbec5-cb37-40f5-a33d-82309c4b9289)

![image](https://github.com/user-attachments/assets/8f5d49c1-c9b9-4789-a2e2-2f48a2d61f0e)
Note that the width is 600px on the parent and the height is 700px (or the screen height space, which ever is lower as we don't want things to run off the screen)